### PR TITLE
update dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
   },
   "dependencies": {
     "continuable-cache": "^0.3.1",
-    "error": "^7.0.0",
-    "raw-body": "~1.1.0",
-    "safe-json-parse": "~1.0.1"
+    "error": "^7.0.2",
+    "raw-body": "~2.1.6",
+    "safe-json-parse": "~4.0.0"
   },
   "devDependencies": {
-    "after": "~0.7.0",
-    "hammock": "^1.0.0",
-    "test-server": "~0.1.3",
-    "send-data": "~1.0.1",
-    "tape": "~2.3.0",
-    "process": "~0.5.1"
+    "after": "~0.8.1",
+    "hammock": "^1.1.0",
+    "test-server": "~0.2.1",
+    "send-data": "~8.0.0",
+    "tape": "~4.5.1",
+    "process": "~0.11.2"
   },
   "licenses": [
     {


### PR DESCRIPTION
```
 raw-body         ~1.1.0  →   ~2.1.6
 safe-json-parse  ~1.0.1  →   ~4.0.0
 after            ~0.7.0  →   ~0.8.1
 test-server      ~0.1.3  →   ~0.2.1
 send-data        ~1.0.1  →   ~8.0.0
 tape             ~2.3.0  →   ~4.5.1
 process          ~0.5.1  →   ~0.11.2
 error            ^7.0.0  →   ^7.0.2
 hammock          ^1.0.0  →   ^1.1.0
```