### PR TITLE
Update the isWritable function

### DIFF
--- a/parse-arguments.js
+++ b/parse-arguments.js
@@ -1,8 +1,11 @@
+var stream = require("stream")
+
 module.exports = parseArguments
 
-function isWritable(stream) {
-    return typeof stream.write === "function" &&
-        typeof stream.end === "function"
+function isWritable(streamToCheck) {
+    return streamToCheck instanceof stream.Stream &&
+        typeof streamToCheck.write === "function" &&
+        typeof streamToCheck.end === "function"
 }
 
 function parseArguments(req, res, opts, callback) {


### PR DESCRIPTION
This update is to make sure that the passed stream parameter is actually an instance of stream, given that the "write" and "end" methods are commonly used for other type of objects.