### PR TITLE
Modernize license entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,7 @@
     "tape": "~2.3.0",
     "process": "~0.5.1"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/Raynos/body/raw/master/LICENSE"
-    }
-  ],
+  "license": : "MIT",
   "scripts": {
     "test": "node ./test/index.js"
   }


### PR DESCRIPTION
Back again, lol. - Same deal as here https://github.com/Raynos/error/pull/26 the package appears unlicensed to npm